### PR TITLE
fix: do not double supervise throttle module

### DIFF
--- a/lib/buffy/throttle.ex
+++ b/lib/buffy/throttle.ex
@@ -140,7 +140,7 @@ defmodule Buffy.Throttle do
         name = {:via, unquote(registry_module), {unquote(registry_name), {__MODULE__, key}}}
 
         with {:error, {:already_started, pid}} <- GenServer.start_link(__MODULE__, {key, args}, name: name) do
-          {:ok, pid}
+          :ignore
         end
       end
 
@@ -166,7 +166,14 @@ defmodule Buffy.Throttle do
           %{args: args, key: key, module: __MODULE__}
         )
 
-        unquote(supervisor_module).start_child(unquote(supervisor_name), {__MODULE__, {key, args}})
+        case unquote(supervisor_module).start_child(unquote(supervisor_name), {__MODULE__, {key, args}}) do
+          {:ok, pid} ->
+            {:ok, pid}
+
+          :ignore ->
+            [{pid, _}] = unquote(registry_module).lookup(unquote(registry_name), {__MODULE__, key})
+            {:ok, pid}
+        end
       end
 
       @doc """

--- a/test/buffy/throttle_test.exs
+++ b/test/buffy/throttle_test.exs
@@ -21,6 +21,11 @@ defmodule Buffy.ThrottleTest do
     end
   end
 
+  test "returns pid of already running process" do
+    {:ok, pid} = MySlowThrottler.throttle(:testing)
+    assert {:ok, ^pid} = MySlowThrottler.throttle(:testing)
+  end
+
   test "throttles handle_debounce/1" do
     for _ <- 1..200, do: MySlowThrottler.throttle(:testing)
     Process.sleep(100)


### PR DESCRIPTION
This can be related to memory consumption when used with horde.

More info: https://github.com/derekkraan/horde/issues/200