### PR TITLE
fix: ensure to always hash binary version of args

### DIFF
--- a/lib/buffy/throttle.ex
+++ b/lib/buffy/throttle.ex
@@ -158,7 +158,7 @@ defmodule Buffy.Throttle do
       @impl Buffy.Throttle
       @spec throttle(Buffy.Throttle.args()) :: {:ok, pid()}
       def throttle(args) do
-        key = :erlang.phash2(args)
+        key = :erlang.phash2(:erlang.term_to_binary(args))
 
         :telemetry.execute(
           [:buffy, :throttle, :throttle],

--- a/lib/buffy/throttle.ex
+++ b/lib/buffy/throttle.ex
@@ -158,7 +158,7 @@ defmodule Buffy.Throttle do
       @impl Buffy.Throttle
       @spec throttle(Buffy.Throttle.args()) :: {:ok, pid()}
       def throttle(args) do
-        key = :erlang.phash2(:erlang.term_to_binary(args))
+        key = args |> :erlang.term_to_binary() |> :erlang.phash2()
 
         :telemetry.execute(
           [:buffy, :throttle, :throttle],


### PR DESCRIPTION
This seems to generate more uniqueness in the hash than atoms. From an upstream conversation on the erlang email list.

http://erlang.org/pipermail/erlang-questions/2009-May/043653.html