### PR TITLE
fix!: return :ok for already started throttle processes

### DIFF
--- a/lib/buffy/throttle.ex
+++ b/lib/buffy/throttle.ex
@@ -156,7 +156,7 @@ defmodule Buffy.Throttle do
 
       """
       @impl Buffy.Throttle
-      @spec throttle(Buffy.Throttle.args()) :: {:ok, pid()}
+      @spec throttle(Buffy.Throttle.args()) :: :ok | {:error, term()}
       def throttle(args) do
         key = args |> :erlang.term_to_binary() |> :erlang.phash2()
 
@@ -167,12 +167,9 @@ defmodule Buffy.Throttle do
         )
 
         case unquote(supervisor_module).start_child(unquote(supervisor_name), {__MODULE__, {key, args}}) do
-          {:ok, pid} ->
-            {:ok, pid}
-
-          :ignore ->
-            [{pid, _}] = unquote(registry_module).lookup(unquote(registry_name), {__MODULE__, key})
-            {:ok, pid}
+          {:ok, pid} -> :ok
+          :ignore -> :ok
+          result -> result
         end
       end
 

--- a/test/buffy/throttle_test.exs
+++ b/test/buffy/throttle_test.exs
@@ -15,15 +15,10 @@ defmodule Buffy.ThrottleTest do
   @tag timeout: :timer.minutes(10)
   test "calls handle_debounce/1" do
     check all args <- StreamData.term() do
-      assert {:ok, _pid} = MyZeroThrottler.throttle(args)
+      assert :ok = MyZeroThrottler.throttle(args)
       Process.sleep(1)
       assert_called MyZeroThrottler.handle_throttle(args)
     end
-  end
-
-  test "returns pid of already running process" do
-    {:ok, pid} = MySlowThrottler.throttle(:testing)
-    assert {:ok, ^pid} = MySlowThrottler.throttle(:testing)
   end
 
   test "throttles handle_debounce/1" do


### PR DESCRIPTION
I tried to return a pid in this case to avoid a breaking change, but we're now hitting issues where the process closes between the two function calls resulting in a no match error.

BREAKING CHANGE: `Buffy.Throttle.throttle/1` will now return `:ok` instead of `{:ok, pid}`