### PR TITLE
feat: add jitter option to throttle function

### DIFF
--- a/lib/buffy/throttle.ex
+++ b/lib/buffy/throttle.ex
@@ -223,7 +223,7 @@ defmodule Buffy.Throttle do
       @impl GenServer
       @spec handle_info(:timeout, Buffy.Throttle.state()) :: {:stop, :normal, Buffy.Throttle.state()}
       def handle_info(:timeout, {key, args}) do
-        selected_jitter = :rand.uniform(unquote(jitter) + 1) - 1
+        selected_jitter = min(:rand.uniform(unquote(jitter) + 1) - 1, 0)
 
         :telemetry.execute([:buffy, :throttle, :handle, :jitter], %{jitter: selected_jitter}, %{
           args: args,

--- a/lib/buffy/throttle.ex
+++ b/lib/buffy/throttle.ex
@@ -223,11 +223,10 @@ defmodule Buffy.Throttle do
       @impl GenServer
       @spec handle_info(:timeout, Buffy.Throttle.state()) :: {:stop, :normal, Buffy.Throttle.state()}
       def handle_info(:timeout, {key, args}) do
-        selected_jitter = 1 - :rand.uniform(unquote(jitter) + 1)
+        selected_jitter = :rand.uniform(unquote(jitter) + 1) - 1
 
-        :telemetry.execute([:buffy, :throttle, :handle, :jitter], %{
+        :telemetry.execute([:buffy, :throttle, :handle, :jitter], %{jitter: selected_jitter}, %{
           args: args,
-          jitter: selected_jitter,
           key: key,
           module: __MODULE__
         })

--- a/lib/buffy/throttle.ex
+++ b/lib/buffy/throttle.ex
@@ -223,7 +223,7 @@ defmodule Buffy.Throttle do
       @impl GenServer
       @spec handle_info(:timeout, Buffy.Throttle.state()) :: {:stop, :normal, Buffy.Throttle.state()}
       def handle_info(:timeout, {key, args}) do
-        selected_jitter = min(:rand.uniform(unquote(jitter) + 1) - 1, 0)
+        selected_jitter = max(:rand.uniform(unquote(jitter) + 1) - 1, 0)
 
         :telemetry.execute([:buffy, :throttle, :handle, :jitter], %{jitter: selected_jitter}, %{
           args: args,

--- a/test/support/my_jitter_throttler.ex
+++ b/test/support/my_jitter_throttler.ex
@@ -1,0 +1,9 @@
+defmodule MyJitterThrottler do
+  use Buffy.Throttle,
+    jitter: 100,
+    throttle: 0
+
+  def handle_throttle(_args) do
+    :ok
+  end
+end


### PR DESCRIPTION
This allows adding Jitter to the throttle module. This allows adding a bit of randomosity to the throttle handle function. Allowing you to avoid storms of throttle functions starting at the same time.

Pooling coming in a later PR.