### PR TITLE
feat: SIGNAL-5811 add time interval bucket feature to ThrottleAndTimed and make loop_interval optional

### DIFF
--- a/lib/buffy/throttle_and_timed.ex
+++ b/lib/buffy/throttle_and_timed.ex
@@ -428,8 +428,9 @@ defmodule Buffy.ThrottleAndTimed do
       Uses result and updates state.
       Defaults to returning the existing state.
       """
-      @spec update_state_with_work_result(state :: %{timer_ref: reference() | nil}, result :: any()) :: %{
-              timer_ref: reference() | nil
+      @spec update_state_with_work_result(state :: %{:args => any(), any() => any()}, result :: any()) :: %{
+              :args => any(),
+              any() => any()
             }
       def update_state_with_work_result(state, _result) do
         state

--- a/lib/buffy/throttle_and_timed.ex
+++ b/lib/buffy/throttle_and_timed.ex
@@ -233,7 +233,7 @@ defmodule Buffy.ThrottleAndTimed do
     supervisor_module = Keyword.get(opts, :supervisor_module, DynamicSupervisor)
     supervisor_name = Keyword.get(opts, :supervisor_name, Buffy.DynamicSupervisor)
     throttle = Keyword.fetch!(opts, :throttle)
-    loop_interval = Keyword.get(opts, :loop_interval)
+    loop_interval = Keyword.get(opts, :loop_interval, :infinity)
 
     quote do
       @behaviour Buffy.ThrottleAndTimed
@@ -398,21 +398,13 @@ defmodule Buffy.ThrottleAndTimed do
 
         new_state = %{update_state_with_work_result(state, result) | timer_ref: nil}
 
-        if unquote(loop_interval) do
-          {:noreply, new_state, unquote(loop_interval)}
-        else
-          {:noreply, new_state}
-        end
+        {:noreply, new_state, unquote(loop_interval)}
       rescue
         e ->
           Logger.error("Error in throttle: #{inspect(e)}")
           new_state = %{state | timer_ref: nil}
 
-          if unquote(loop_interval) do
-            {:noreply, new_state, unquote(loop_interval)}
-          else
-            {:noreply, new_state}
-          end
+          {:noreply, new_state, unquote(loop_interval)}
       end
 
       @doc """

--- a/lib/buffy/throttle_and_timed.ex
+++ b/lib/buffy/throttle_and_timed.ex
@@ -328,16 +328,6 @@ defmodule Buffy.ThrottleAndTimed do
         %{state | timer_ref: timer_ref}
       end
 
-      @doc """
-      Function that updates the state with incoming args.
-
-      """
-      def update_state_with_args(state, _args) do
-        state
-      end
-
-      defoverridable update_state_with_args: 2
-
       @doc false
       @impl GenServer
       @spec handle_info(:timeout | :execute_throttle_callback, Buffy.ThrottleAndTimed.state()) ::

--- a/lib/buffy/throttle_and_timed.ex
+++ b/lib/buffy/throttle_and_timed.ex
@@ -143,13 +143,10 @@ defmodule Buffy.ThrottleAndTimed do
       end
 
       def update_state_with_work_result(%{args: %{values: state_values} = args} = state, result) do
-        pending_values =
-          state_values
-          |> MapSet.new()
-          |> MapSet.difference(MapSet.new(result))
-          |> MapSet.to_list()
-
-        %{state | args: %{args | values: pending_values}}
+        # because `handle_throttle()` runs in the `:continue` lifecycle of GenServer,
+        # inbox processing is paused until the logic completes. Inbox will continually get new messages,
+        # from calling `throttle()` and will be processed only after completion of `handle_throttle()`.
+        %{state | args: %{args | values: []}}
       end
     end
   ```

--- a/test/buffy/throttle_and_timed_test.exs
+++ b/test/buffy/throttle_and_timed_test.exs
@@ -175,6 +175,65 @@ defmodule Buffy.ThrottleAndTimedTest do
     end
   end
 
+  describe "usage: collecting args to state and running them when :timeout" do
+    defmodule MyTimedSlowBucketingThrottler do
+      @moduledoc """
+      `args` is a map. It will always come in with %{key: "key"}.
+      """
+      use Buffy.ThrottleAndTimed,
+        throttle: 100,
+        loop_interval: 300,
+        supervisor_module: DynamicSupervisor,
+        supervisor_name: MyDynamicSupervisor
+
+      def handle_throttle(%{test_pid: test_pid, values: _values} = args) do
+        send(test_pid, {:ok, args, System.monotonic_time()})
+        :ok
+      end
+
+      def args_to_key(%{key: key}), do: key |> :erlang.term_to_binary() |> :erlang.phash2()
+
+      def update_args(%{values: values} = old_arg, %{values: new_values} = _new_arg)
+          when is_list(values) and is_list(new_values) do
+        %{old_arg | values: Enum.sort(values ++ new_values)}
+      end
+
+      def update_state_with_work_result(%{args: args} = state, _) do
+        %{state | args: %{args | values: []}}
+      end
+    end
+
+    setup do
+      start_supervised!({MyDynamicSupervisor, []})
+      :ok
+    end
+
+    test "should use overrideable functions to use collection of arg values from all of triggers when work is done" do
+      test_pid = self()
+      # trigger throttle
+      MyTimedSlowBucketingThrottler.throttle(%{key: "my_key", test_pid: test_pid, values: [0]})
+
+      # trigger more throttle
+      for x <- 1..10 do
+        Task.async(fn ->
+          MyTimedSlowBucketingThrottler.throttle(%{key: "my_key", test_pid: test_pid, values: [x]})
+        end)
+      end
+
+      # assert throttled work done
+      expected_value = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      assert_receive {:ok, %{values: ^expected_value}, now}, 200
+
+      # refute any other work was done
+      refute_receive {:ok, _, _now}, 200
+
+      # check inbox timeout triggered
+      assert_receive {:ok, _, now2}, 400
+      diff = System.convert_time_unit(now2 - now, :native, :millisecond)
+      assert :erlang.abs(diff - 300) < 10
+    end
+  end
+
   describe ":telemetry" do
     setup do
       :telemetry_test.attach_event_handlers(self(), [

--- a/test/buffy/throttle_and_timed_test.exs
+++ b/test/buffy/throttle_and_timed_test.exs
@@ -231,17 +231,17 @@ defmodule Buffy.ThrottleAndTimedTest do
         end
       end
 
-      # assert throttled work done
       expected_value = [0, 1, 2]
       assert_receive {:ok, %{values: ^expected_value}, handle_throttle_t1}, 350
 
-      # expect
       expected_value = [3, 4, 5, 6, 7, 8, 9, 10]
       assert_receive {:ok, %{values: ^expected_value}, handle_throttle_t2}, 350
 
-      # check inbox timeout triggered
       diff = System.convert_time_unit(handle_throttle_t2 - handle_throttle_t1, :native, :millisecond)
       assert :erlang.abs(diff - 300) < 10
+
+      # refute no time interval fired as :loop_interval is not set
+      refute_receive {:ok, _, _}, 400
     end
   end
 


### PR DESCRIPTION
Change `Buffy.ThrottleAndTimed` to be able to modify data in state for each `throttle()` invoked.
This is additive with additional `defoverridable` functions - original API is intact.
`:loop_interval` option has looser requirement as it became optional.

Example use case: let's say for some event handler operation, we process an id by querying into the DB.

If that happens a thousand times per second into a connection that takes a lot of CPU/memory, like Postgres DB,
then making a thousand query connections per second would be significantly expensive compared to one connection with a list of thousand ids - let's say the same query ends up returning a list, regardless of one id or list of ids (logic only differs by input size of ids list).

In that case we need a way to collect ids across some set of events. 

`Buffy.ThrottleAndTimed` already has bulk of the timing mechanism in place:
- it is a process that will not get killed once throttle work is done
- it has throttling logic
- it can be modified to have three additional `defoverridable` functions for key generating, args updating, and state update upon successful work operations.
- it can be modified so the loop interval feature is optional.

Example use (also noted in moduledoc):

```
    defmodule MyElasticEventThrottler do
      use Buffy.ThrottleAndTimed,
        throttle: 100,
        supervisor_module: DynamicSupervisor,
        supervisor_name: MyDynamicSupervisor

      def handle_throttle(%{test_pid: test_pid, values: values} = args) do
        Process.sleep(200)
        send(test_pid, {:ok, args, System.monotonic_time()})
        values
      end

      def args_to_key(%{key: key}), do: key |> :erlang.term_to_binary() |> :erlang.phash2()

      def update_args(%{values: values} = old_arg, %{values: new_values} = _new_arg)
          when is_list(values) and is_list(new_values) do
        %{old_arg | values: Enum.sort(values ++ new_values)}
      end

      def update_state_with_work_result(%{args: %{values: state_values} = args} = state, result_values) do
        # because `handle_throttle()` runs in the `:continue` lifecycle of GenServer,
        # inbox processing is paused until the logic completes. Inbox will continually get new messages,
        # from calling `throttle()` and will be processed only after completion of `handle_throttle()`.
        %{state | args: %{args | values: []}}
      end
    end

# ... and using it:
MyElasticEventThrottler.throttle(%{key: "my_key", test_pid: test_pid, values: [0,1,2,3]})
```

Also see the added test for a more thorough use case.