### PR TITLE
feat: add telemetry metric for process memory usage

### DIFF
--- a/lib/buffy/throttle.ex
+++ b/lib/buffy/throttle.ex
@@ -90,6 +90,14 @@ defmodule Buffy.Throttle do
 
   - `:result` - The return value of the `handle_throttle/1` function.
 
+  ### Memory Leaks
+
+  With any sort of debounce and Elixir processes, you need to be careful about handling too many processes, or having to much state in memory at the same time. If you handle large amounts of data there is a good chance you'll end up with high memory usage and possibly affect other parts of your system.
+
+  To help monitor this usage, Buffy has a telemetry metric that measures the Elixir process memory usage. If you summarize this metric you should get a good view into your buffy throttle processes.
+
+      summary("buffy.throttle.total_heap_size", tags: [:module])
+
   """
 
   @typedoc """
@@ -216,7 +224,32 @@ defmodule Buffy.Throttle do
       @spec init(Buffy.Throttle.state()) :: {:ok, Buffy.Throttle.state()}
       def init({key, args}) do
         Process.send_after(self(), :timeout, unquote(throttle))
-        {:ok, {key, args}}
+        {:ok, {key, args}, {:continue, :measure_memory}}
+      end
+
+      @doc false
+      @impl GenServer
+      @spec handle_continue(:measure_memory, Buffy.Throttle.state()) :: {:noreply, Buffy.Throttle.state()}
+      def handle_continue(:measure_memory, {key, args} = state) do
+        case Process.info(self(), [:total_heap_size]) do
+          [{:total_heap_size, total_heap_size}] ->
+            :telemetry.execute(
+              [:buffy, :throttle],
+              %{
+                total_heap_size: total_heap_size
+              },
+              %{
+                args: args,
+                key: key,
+                module: __MODULE__
+              }
+            )
+
+          _ ->
+            nil
+        end
+
+        {:noreply, state}
       end
 
       @doc false

--- a/test/buffy/throttle_and_timed_test.exs
+++ b/test/buffy/throttle_and_timed_test.exs
@@ -248,6 +248,7 @@ defmodule Buffy.ThrottleAndTimedTest do
   describe ":telemetry" do
     setup do
       :telemetry_test.attach_event_handlers(self(), [
+        [:buffy, :throttle],
         [:buffy, :throttle, :throttle],
         [:buffy, :throttle, :timeout],
         [:buffy, :throttle, :handle, :start],
@@ -258,6 +259,19 @@ defmodule Buffy.ThrottleAndTimedTest do
       start_supervised!({MyDynamicSupervisor, []})
 
       :ok
+    end
+
+    test "emits [:buffy, :throttle] total_heap_size" do
+      MyZeroThrottler.throttle(:foo)
+
+      assert_receive {[:buffy, :throttle], _ref, %{total_heap_size: heap},
+                      %{
+                        args: :foo,
+                        key: _,
+                        module: MyZeroThrottler
+                      }}
+
+      assert heap > 0
     end
 
     test "emits [:buffy, :throttle, :throttle]" do

--- a/test/buffy/throttle_test.exs
+++ b/test/buffy/throttle_test.exs
@@ -31,6 +31,7 @@ defmodule Buffy.ThrottleTest do
     setup do
       _ref =
         :telemetry_test.attach_event_handlers(self(), [
+          [:buffy, :throttle],
           [:buffy, :throttle, :throttle],
           [:buffy, :throttle, :handle, :jitter],
           [:buffy, :throttle, :handle, :start],
@@ -39,6 +40,19 @@ defmodule Buffy.ThrottleTest do
         ])
 
       :ok
+    end
+
+    test "emits [:buffy, :throttle] total_heap_size" do
+      MyZeroThrottler.throttle(:foo)
+
+      assert_receive {[:buffy, :throttle], _ref, %{total_heap_size: heap},
+                      %{
+                        args: :foo,
+                        key: _,
+                        module: MyZeroThrottler
+                      }}
+
+      assert heap > 0
     end
 
     test "emits [:buffy, :throttle, :throttle]" do


### PR DESCRIPTION
## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [X] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem

We sometimes run into memory issues with passing in too many args into buffy.

## Details

This adds a metric about the heap memory size for the buffy process. So now we can summarize the memory usage and get some better data.