### PR TITLE
fix: use :name option for DynamicSupervisor.start_link calls

### DIFF
--- a/lib/buffy/throttle.ex
+++ b/lib/buffy/throttle.ex
@@ -178,7 +178,7 @@ defmodule Buffy.Throttle do
           %{args: args, key: key, module: __MODULE__}
         )
 
-        case unquote(supervisor_module).start_child(unquote(supervisor_name), {__MODULE__, {key, args}}) do
+        case unquote(supervisor_module).start_child(unquote(supervisor_name), {__MODULE__, {key, args}}, [:name, __MODULE__]) do
           {:ok, pid} -> :ok
           :ignore -> :ok
           result -> result


### PR DESCRIPTION
## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [x] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem

We have had incidents where consumer lag spikes, and this is to implement a recommendation from comment:

https://github.com/derekkraan/horde/issues/256

<!--
What is the problem you're solving or feature you're implementing? Link to any Jira tickets or previous discussions of the issue.
-->

## Details

Add the option on the `start_link` as indicated by the comment in the github issue in Horde's repo.

<!--
Include a brief overview of the technical process you took (or are going to take!) to get from the problem to the solution.
-->
